### PR TITLE
Adjust loggers in integration manifest

### DIFF
--- a/custom_components/package_concierge/manifest.json
+++ b/custom_components/package_concierge/manifest.json
@@ -3,6 +3,7 @@
     "name": "Package Concierge",
     "documentation": "https://github.com/corbanmailloux/package-concierge-hass",
     "issue_tracker": "https://github.com/corbanmailloux/package-concierge-hass/issues",
+    "loggers": ["custom_components.package_concierge"],
     "requirements": [
         "requests",
         "beautifulsoup4"


### PR DESCRIPTION
Should fix logging properly, ref https://github.com/home-assistant/core/issues/84489.